### PR TITLE
Improve CORS and docker conversion call

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -18,12 +18,16 @@ const MERGED_OUTPUT_DIR_FOR_MERGE = path.join(__dirname, "merged_output");
 const app = express();
 
 /* ----------  CORS  ---------- */
-app.use(cors({
+const corsOptions = {
   origin: "https://magicfile.ai",
-  methods: ["GET","POST","PUT","DELETE","OPTIONS"],
-  allowedHeaders: ["Content-Type","Authorization","X-Requested-With"],
-  credentials: true
-}));
+  methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+  allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
+  credentials: true,
+};
+
+app.use(cors(corsOptions));
+// handle preflight requests for all routes
+app.options(/.*/, cors(corsOptions));
 
 /* ----------  MIDDLEWARES  ---------- */
 app.use(express.json());
@@ -52,7 +56,8 @@ app.post("/convert", uploadConvert.single("file"), (req,res)=>{
   const target  = req.query.target || "pdf";
   const inFile  = req.file.filename;
   const outFile = `${path.parse(inFile).name}.${target}`;
-  const cmd     = `libreoffice --headless --convert-to ${target} --outdir ${OUT_DIR} ${IN_DIR}/${inFile}`;
+  // use the dedicated converter container via docker exec
+  const cmd     = `docker exec converter-converter-1 unoconv -f ${target} -o /output/${outFile} /input/${inFile}`;
 
   exec(cmd,(err)=>{
     if(err){

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const express = require('express');
 const multer = require('multer');
 const PDFMerger = require('pdf-merger-js');
 const { v4: uuidv4 } = require('uuid');
-const path = require('path');
 const fs = require('fs');
 
 const app = express();
@@ -35,6 +34,7 @@ app.post('/merge', upload.array('files'), async (req, res) => {
 });
 
 // מאזין
-app.listen(3000, () => {
-    console.log('🚀 MagicFile.ai API running on port 3000');
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+    console.log(`🚀 MagicFile.ai API running on port ${PORT}`);
 });


### PR DESCRIPTION
## Summary
- tweak CORS middleware to respond to preflight requests
- call LibreOffice conversion through the `converter` container

## Testing
- `npm install`
- `npm --prefix app install`
- `node app/index.js & sleep 1; pkill node`

------
https://chatgpt.com/codex/tasks/task_e_6841c9be7a7c83248ca81b1764224836